### PR TITLE
Removed vars

### DIFF
--- a/Analyzers/NWPluginAPI.Analyzers.CodeFixes/NWPluginAPIAnalyzersCodeFixProvider.cs
+++ b/Analyzers/NWPluginAPI.Analyzers.CodeFixes/NWPluginAPIAnalyzersCodeFixProvider.cs
@@ -32,14 +32,14 @@ namespace NWPluginAPI.Analyzers
 
 		public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
 		{
-			var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+			SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
 			// TODO: Replace the following code with your own analysis, generating a CodeAction for each fix to suggest
-			var diagnostic = context.Diagnostics.First();
-			var diagnosticSpan = diagnostic.Location.SourceSpan;
+			Diagnostic diagnostic = context.Diagnostics.First();
+			TextSpan diagnosticSpan = diagnostic.Location.SourceSpan;
 
 			// Find the type declaration identified by the diagnostic.
-			var declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
+			MethodDeclarationSyntax declaration = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<MethodDeclarationSyntax>().First();
 
 			// Register a code action that will invoke the fix.
 			context.RegisterCodeFix(
@@ -52,15 +52,15 @@ namespace NWPluginAPI.Analyzers
 
 		private async Task<Document> MakeUppercaseAsync(Document document, MethodDeclarationSyntax param, CancellationToken cancellationToken)
 		{
-			var attribute = SyntaxFactory.AttributeList(
+			AttributeListSyntax attribute = SyntaxFactory.AttributeList(
 	SyntaxFactory.SingletonSeparatedList<AttributeSyntax>(
 		SyntaxFactory.Attribute(SyntaxFactory.IdentifierName("PluginEvent"), null)));
 						
-			var newParam = param.WithAttributeLists(param.AttributeLists.Add(attribute));
+			MethodDeclarationSyntax newParam = param.WithAttributeLists(param.AttributeLists.Add(attribute));
 
-			var root = await document.GetSyntaxRootAsync();
-			var newRoot = root.ReplaceNode(param, newParam);
-			var newDocument = document.WithSyntaxRoot(newRoot);
+			SyntaxNode root = await document.GetSyntaxRootAsync();
+			SyntaxNode newRoot = root.ReplaceNode(param, newParam);
+			Document newDocument = document.WithSyntaxRoot(newRoot);
 
 			return newDocument;
 		}

--- a/Analyzers/NWPluginAPI.Analyzers/NWPluginAPIAnalyzersAnalyzer.cs
+++ b/Analyzers/NWPluginAPI.Analyzers/NWPluginAPIAnalyzersAnalyzer.cs
@@ -37,9 +37,9 @@ namespace NWPluginAPI.Analyzers
 		private static void AnalyzeSymbol(SymbolAnalysisContext context)
 		{
 			// TODO: Replace the following code with your own analysis, generating Diagnostic objects for any issues you find
-			var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+			INamedTypeSymbol namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
 
-			var diagnostic = Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], namedTypeSymbol.Name);
+			Diagnostic diagnostic = Diagnostic.Create(Rule, namedTypeSymbol.Locations[0], namedTypeSymbol.Name);
 
 			context.ReportDiagnostic(diagnostic);
 		}

--- a/NwPluginAPI/Commands/ListCommand.cs
+++ b/NwPluginAPI/Commands/ListCommand.cs
@@ -1,10 +1,9 @@
-using PluginAPI.Core;
-
 namespace PluginAPI.Commands
 {
     using System;
     using System.Collections.Generic;
     using CommandSystem;
+    using PluginAPI.Core;
     using PluginAPI.Loader;
 
     [CommandHandler(typeof(PluginsCommand))]

--- a/NwPluginAPI/Commands/ListCommand.cs
+++ b/NwPluginAPI/Commands/ListCommand.cs
@@ -1,3 +1,5 @@
+using PluginAPI.Core;
+
 namespace PluginAPI.Commands
 {
     using System;
@@ -18,7 +20,7 @@ namespace PluginAPI.Commands
 		public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
 		{
 			List<string> plugins = new List<string>();
-			foreach (var plugin in AssemblyLoader.InstalledPlugins)
+			foreach (PluginHandler plugin in AssemblyLoader.InstalledPlugins)
 			{
 				plugins.Add($"<color=lime>{(plugin.PluginName)}</color> v<color=orange>{plugin.PluginVersion}</color>");
 			}

--- a/NwPluginAPI/Commands/ReloadCommand.cs
+++ b/NwPluginAPI/Commands/ReloadCommand.cs
@@ -1,8 +1,7 @@
-using PluginAPI.Core;
-
 namespace PluginAPI.Commands
 {
 	using CommandSystem;
+	using PluginAPI.Core;
 	using PluginAPI.Loader;
 	using System;
 	using System.Collections.Generic;

--- a/NwPluginAPI/Commands/ReloadCommand.cs
+++ b/NwPluginAPI/Commands/ReloadCommand.cs
@@ -1,3 +1,5 @@
+using PluginAPI.Core;
+
 namespace PluginAPI.Commands
 {
 	using CommandSystem;
@@ -15,7 +17,7 @@ namespace PluginAPI.Commands
 		public bool Execute(ArraySegment<string> arguments, ICommandSender sender, out string response)
 		{
 			List<string> plugins = new List<string>();
-			foreach (var plugin in AssemblyLoader.InstalledPlugins)
+			foreach (PluginHandler plugin in AssemblyLoader.InstalledPlugins)
 			{
 				plugins.Add($"<color=lime>{(plugin.PluginName)}</color>");
 			}

--- a/NwPluginAPI/Core/Extensions/ReflectionExtensions.cs
+++ b/NwPluginAPI/Core/Extensions/ReflectionExtensions.cs
@@ -8,9 +8,9 @@
     {
         public static bool IsValidEntrypoint(this Type type)
         {
-            foreach(var method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            foreach(MethodInfo method in type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
-                var attr = method.GetCustomAttribute<PluginEntryPoint>();
+                PluginEntryPoint attr = method.GetCustomAttribute<PluginEntryPoint>();
                 if (attr != null)
                     return true;
             }

--- a/NwPluginAPI/Core/Factories/Factory.cs
+++ b/NwPluginAPI/Core/Factories/Factory.cs
@@ -36,7 +36,7 @@
                 return entity;
             }
 
-            var ent = Create(component);
+            T ent = Create(component);
             Entities.Add(component, ent);
             return ent;
         }

--- a/NwPluginAPI/Core/FactoryManager.cs
+++ b/NwPluginAPI/Core/FactoryManager.cs
@@ -28,7 +28,7 @@
 		/// <param name="factory">The factory.</param>
         public static void RegisterPlayerFactory(object plugin, PlayerFactory factory)
         {
-            var type = plugin.GetType();
+            Type type = plugin.GetType();
 
             if (PlayerFactories.ContainsKey(type)) return;
 
@@ -49,9 +49,9 @@
 
         static void OnUpdate()
         {
-            foreach (var factory in PlayerFactories.Values)
+            foreach (PlayerFactory factory in PlayerFactories.Values)
             {
-                foreach(var entity in factory.Entities)
+                foreach(KeyValuePair<IGameComponent, IPlayer> entity in factory.Entities)
                 {
                     entity.Value.OnUpdate();
                 }
@@ -60,9 +60,9 @@
 
         static void OnLateUpdate()
         {
-            foreach (var factory in PlayerFactories.Values)
+            foreach (PlayerFactory factory in PlayerFactories.Values)
             {
-                foreach (var entity in factory.Entities)
+                foreach (KeyValuePair<IGameComponent, IPlayer> entity in factory.Entities)
                 {
                     try
                     {
@@ -78,9 +78,9 @@
 
         static void OnFixedUpdate()
         {
-            foreach (var factory in PlayerFactories.Values)
+            foreach (PlayerFactory factory in PlayerFactories.Values)
             {
-                foreach (var entity in factory.Entities)
+                foreach (KeyValuePair<IGameComponent, IPlayer> entity in factory.Entities)
                 {
                     try
                     {
@@ -96,7 +96,7 @@
 
         static void RemovePlayer(ReferenceHub obj)
         {
-            foreach(var factory in PlayerFactories.Values)
+            foreach(PlayerFactory factory in PlayerFactories.Values)
             {
                 if (factory.Entities.TryGetValue(obj, out IPlayer plr))
                 {

--- a/NwPluginAPI/Core/Items/ItemPickup.cs
+++ b/NwPluginAPI/Core/Items/ItemPickup.cs
@@ -39,7 +39,7 @@ namespace PluginAPI.Core.Items
 				return it;
 			else
 			{
-				var newItem = new ItemPickup(item);
+				ItemPickup newItem = new ItemPickup(item);
 				CachedItems.Add(item.Info.Serial, newItem);
 				return newItem;
 			}

--- a/NwPluginAPI/Core/PluginHandler.cs
+++ b/NwPluginAPI/Core/PluginHandler.cs
@@ -104,9 +104,9 @@ namespace PluginAPI.Core
 			_plugin = Activator.CreateInstance(type);
             _pluginType = _plugin.GetType();
 
-            foreach (var method in _pluginType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            foreach (MethodInfo method in _pluginType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
 			{
-				var attribute = method.GetCustomAttribute<Attribute>();
+				Attribute attribute = method.GetCustomAttribute<Attribute>();
 
 				switch (attribute)
 				{
@@ -132,9 +132,9 @@ namespace PluginAPI.Core
                 Log.Info($"Created missing plugin directory for \"{PluginName}\".");
             }
 
-            foreach (var field in _pluginType.GetFields())
+            foreach (FieldInfo field in _pluginType.GetFields())
 			{
-                var attribute = field.GetCustomAttribute<Attribute>();
+                Attribute attribute = field.GetCustomAttribute<Attribute>();
 
                 switch (attribute)
 				{
@@ -145,7 +145,7 @@ namespace PluginAPI.Core
                         if (!File.Exists(Path.Combine(_pluginDirectory.Plugins, _entryInfo.Name, "config.yml")))
                         {
 
-                            var defaultConfig = Activator.CreateInstance(_configType);
+                            object defaultConfig = Activator.CreateInstance(_configType);
 
                             _configInfo.SetValue(_plugin, defaultConfig);
 

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -162,15 +162,15 @@ namespace PluginAPI.Events
 				_handlerInstances.Add(eventHandler, handle);
             }
 
-            foreach (var method in eventHandler.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            foreach (MethodInfo method in eventHandler.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
 			{
-                var attribute = method.GetCustomAttribute<Attribute>();
+                Attribute attribute = method.GetCustomAttribute<Attribute>();
 
                 switch (attribute)
 				{
 					case PluginEvent pluginEvent:
 
-                        var eventParameters = method.GetParameters().Select(p => p.ParameterType).ToArray();
+                        Type[] eventParameters = method.GetParameters().Select(p => p.ParameterType).ToArray();
 
 						if (!ValidateEvent(eventParameters, _requiredParameters[(int)pluginEvent.EventType]))
 						{
@@ -225,7 +225,7 @@ namespace PluginAPI.Events
 			List<IndexInfo> indexesToRegenerate = new List<IndexInfo>();
 			for(int x = 0; x < _requiredParameters[(int)type].Length; x++)
 			{
-				var paramType = _requiredParameters[(int)type][x];
+				Type paramType = _requiredParameters[(int)type][x];
 
                 if (args[x] == null)
 				{
@@ -244,9 +244,9 @@ namespace PluginAPI.Events
 
 			bool isCanceled = false;
 
-			foreach (var ev in registeredEvents)
+			foreach (EventInfo ev in registeredEvents)
 			{
-				foreach (var index in indexesToRegenerate)
+				foreach (IndexInfo index in indexesToRegenerate)
 				{
 					if (index.Type == typeof(IPlayer))
 					{

--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -60,9 +60,9 @@ namespace PluginAPI.Loader
 			LoadPlugins(Paths.LocalPlugins);
 
 			Log.Info("<---<       Start all plugins       <---<");
-			foreach (var plugin in Plugins.Values)
+			foreach (Dictionary<Type, PluginHandler> plugin in Plugins.Values)
 			{
-				foreach (var pluginType in plugin.Values)
+				foreach (PluginHandler pluginType in plugin.Values)
 				{
 					try
 					{
@@ -93,7 +93,7 @@ namespace PluginAPI.Loader
                 if (!TryGetAssembly(dependencyPath, out Assembly assembly))
 					continue;
 
-                foreach (var type in assembly.GetTypes())
+                foreach (Type type in assembly.GetTypes())
 				{
 					if (!type.IsValidEntrypoint()) continue;
 

--- a/TemplatePlugin/MainClass.cs
+++ b/TemplatePlugin/MainClass.cs
@@ -33,7 +33,7 @@
         {
             Log.Info($"Player &6{player.UserId}&r joined this server with &1{player.Test}&4");
 
-            foreach(var plr in Player.GetPlayers<MyPlayer>())
+            foreach(MyPlayer plr in Player.GetPlayers<MyPlayer>())
             {
                 Log.Info($"Player online &6{plr.Nickname}&r, role &6{plr.Role}&r");
             }


### PR DESCRIPTION
Using vars in a language like C# is a bad practice and may leed to confusion even if property is named propellery. The easiest way to not have problems later is always specifing the type of a variable explicitily.