### PR TITLE
Upload build arifacts

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,4 +36,9 @@ jobs:
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
-      run: dotnet build --no-restore
+      run: dotnet build --no-restore --configuration Release
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with: 
+        name: PluginAPI
+        path: NwPluginAPI/bin/Release/PluginAPI.dll


### PR DESCRIPTION
This PR makes the workflow upload the PluginAPI.dll file so that it may be used as a reference for building plugins. The source code for this binary is freely available, so I see no issue with uploading the binary. The main goal of doing so is to let plugin authors port their plugins over to the API in preparation for the 12.0 release, and to spot any problems/missing features before the release comes out. Of course, plugins can't be ported with this binary alone, but it will allow the majority of the work be completed.