### PR TITLE
Dependency check does not take plugins that embed dependencies into account.

### DIFF
--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -130,7 +130,7 @@ namespace PluginAPI.Loader
                 {
 	                types = assembly.GetTypes();
                 }
-                catch
+                catch (Exception e)
                 {
 	                var missingDependencies = assembly
 		                .GetReferencedAssemblies()
@@ -143,6 +143,8 @@ namespace PluginAPI.Loader
 		                Log.Error($"Failed loading plugin &2{Path.GetFileNameWithoutExtension(pluginPath)}&r, missing dependencies\n&2{string.Join("\n", missingDependencies.Select(x => $"&r - &2{x}&r"))}", "Loader");
 		                continue;
 	                }
+	                
+	                Log.Error($"Failed loading plugin &2{Path.GetFileNameWithoutExtension(pluginPath)}&r, {e.ToString()}");
 	                continue;
                 }
 

--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -253,7 +253,7 @@ namespace PluginAPI.Loader
 			foreach (var name in resourceNames)
 			{
 				Log.Debug($"Found {name}", Log.DebugMode);
-				if (name.EndsWith(".dll"))
+				if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
 				{
 					using (MemoryStream stream = new MemoryStream())
 					{

--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -240,6 +240,10 @@ namespace PluginAPI.Loader
 			return false;
 		}
 		
+		/// <summary>
+		/// Attempts to load Embedded assemblies (compressed) from the target
+		/// </summary>
+		/// <param name="target">Assembly to check for embedded assemblies</param>
 		private static void ResolveAssemblyEmbeddedResources(Assembly target)
 		{
 			Log.Debug($"Attempting to load embedded resources for {target.FullName}", Log.DebugMode);

--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -270,7 +270,7 @@ namespace PluginAPI.Loader
 						Log.Debug($"Loaded {name}", Log.DebugMode);
 					}
 				}
-				else if (name.EndsWith(".dll.compressed"))
+				else if (name.EndsWith(".dll.compressed", StringComparison.OrdinalIgnoreCase))
 				{
 					var dataStream = target.GetManifestResourceStream(name);
 					if (dataStream == null)

--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -124,19 +124,27 @@ namespace PluginAPI.Loader
                 if (!TryGetAssembly(pluginPath, out Assembly assembly))
 					continue;
 
-				var missingDependencies = assembly
-					.GetReferencedAssemblies()
-					.Select(x => 
-						$"{x.Name}&r v&6{x.Version.ToString(3)}")
-					.Where(x => !loadedAssemblies.Contains(x)).ToArray();
+                Type[] types = null;
 
-				if (missingDependencies.Length != 0)
-				{
-					Log.Error($"Failed loading plugin &2{Path.GetFileNameWithoutExtension(pluginPath)}&r, missing dependencies\n&2{string.Join("\n", missingDependencies.Select(x => $"&r - &2{x}&r"))}", "Loader");
-					continue;
-				}
+                try
+                {
+	                types = assembly.GetTypes();
+                }
+                catch
+                {
+	                var missingDependencies = assembly
+		                .GetReferencedAssemblies()
+		                .Select(x => 
+			                $"{x.Name}&r v&6{x.Version.ToString(3)}")
+		                .Where(x => !loadedAssemblies.Contains(x)).ToArray();
 
-				var types = assembly.GetTypes();
+	                if (missingDependencies.Length != 0)
+	                {
+		                Log.Error($"Failed loading plugin &2{Path.GetFileNameWithoutExtension(pluginPath)}&r, missing dependencies\n&2{string.Join("\n", missingDependencies.Select(x => $"&r - &2{x}&r"))}", "Loader");
+		                continue;
+	                }
+	                continue;
+                }
 
 				foreach (var entryType in types)
 				{


### PR DESCRIPTION
Previously, the Loader would always check for dependencies, which causes issues with loading plugins which Embed their dependencies with tools such as CosturaFody.

The loader will first check if all dependencies are met, if they are not. it will attempt to load assemblies embedded in the plugins Assembly Eg by CosturaFody, (supports compression)

As GetTypes will throw an exception when a type inherits something from an Assembly that is not loaded yet, i decided to do the Embedded assembly loading, If the plugin uses CosturaFody it would be loaded when the plugin loads, but it doesnt seem to initialize in time to avoid an exception

And then it will try to load the plugin, and print an error if it still errors

This change has been tested on a plugin which uses CosturaFody to embed resources on the latest patreon beta `12.0.0-patreon-beta-8-32a2f36f`

I am unsure if there are any better ways to go about this, but this is the most effective way i have thought of so far.