### PR TITLE
**Priority Changes**

### DIFF
--- a/NwPluginAPI/Core/Attributes/PluginPriority.cs
+++ b/NwPluginAPI/Core/Attributes/PluginPriority.cs
@@ -9,13 +9,22 @@
 	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
 	public class PluginPriority : Attribute
 	{
-		public LoadPriority Priority { get; }
+		public byte Priority { get; }
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PluginPriority"/> class.
 		/// </summary>
 		/// <param name="priority">The <see cref="LoadPriority"/>.</param>
 		public PluginPriority(LoadPriority priority)
+		{
+			Priority = (byte)priority;
+		}
+		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="PluginPriority"/> class.
+		/// </summary>
+		/// <param name="priority">The <see cref="LoadPriority"/>.</param>
+		public PluginPriority(byte priority)
 		{
 			Priority = priority;
 		}

--- a/NwPluginAPI/Core/PluginHandler.cs
+++ b/NwPluginAPI/Core/PluginHandler.cs
@@ -52,7 +52,7 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Gets the loading priority.
 		/// </summary>
-		public LoadPriority LoadPriority { get; private set; } = LoadPriority.Highest;
+		public byte LoadPriority { get; } = 128;
 
 		/// <summary>
 		/// Gets the name of the plugin.

--- a/NwPluginAPI/Enums/LoadPriority.cs
+++ b/NwPluginAPI/Enums/LoadPriority.cs
@@ -5,10 +5,10 @@ namespace PluginAPI.Enums
 	/// </summary>
 	public enum LoadPriority : byte
 	{
-		Highest = 0,
-		High = 1,
-		Medium = 2,
-		Low = 3,
-		Lowest = 4
+		Highest = 64,
+		High = 96,
+		Medium = 128,
+		Low = 160,
+		Lowest = 192
 	}
 }


### PR DESCRIPTION
We had a conversation around this inside #early-acces-discussion chat on discord. Basically this grants devs an higher range of priorities to use. Useful for a large base of plugins.

- Setted up as the default priority 128 (Medium)
- Changed the functionallity of the PluginPriorityAttribute by using byte as the default instead of the enum.
- Added a new constructor for this attribute that has a byte as an argument instead of the enum:

You can now use both:
```cs
[PluginPriority(LoadPriority.Higher)]
```
and
```cs
[PluginPriority(128)]
```