### PR TITLE
Allow parent commands to be registered.

### DIFF
--- a/NwPluginAPI/Commands/CommandsManager.cs
+++ b/NwPluginAPI/Commands/CommandsManager.cs
@@ -90,7 +90,7 @@
 			else
 			{
 				// this is not pretty.
-				Log.Info($"Attempting to register subcommand {activatedCommand.Command} for custom handler / parent command: {commandHandler.Name}");
+				Log.Debug($"Attempting to register subcommand {activatedCommand.Command} for custom handler / parent command: {commandHandler.Name}");
 				foreach (var attributeData in commandHandler.GetCustomAttributesData())
 				{
 					if (attributeData.AttributeType != typeof(CommandHandlerAttribute)) continue;

--- a/NwPluginAPI/Commands/CommandsManager.cs
+++ b/NwPluginAPI/Commands/CommandsManager.cs
@@ -104,8 +104,11 @@
 						Dictionary<string, Command> parentHandlerRegisteredCommands = _registeredCommands[parentCommandHandlerType];
 						// the type referenced in the CommandHandler is a command in itself, it SHOULD extend "ParentCommand".
 						Command parentCommandInstance = parentHandlerRegisteredCommands.Values.FirstOrDefault(x => x.Object.GetType() == commandHandler);
-						ParentCommand parentCommand = parentCommandInstance.Object as ParentCommand;
-						parentCommand?.RegisterCommand(activatedCommand);
+						if (parentCommandHandlerType != null)
+						{
+							ParentCommand parentCommand = parentCommandInstance.Object as ParentCommand;
+							parentCommand?.RegisterCommand(activatedCommand);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Parent commands aren't registered properly at the moment, meaning only top-level commands in plugins can be used.

This isn't the cleanest implementation, but it works. 