### PR TITLE
Added ban storage events, fixed Paths, added Warhead.IsLocked, changed .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,7 @@
-﻿[*.cs]
+﻿[*]
+charset = utf-8
+
+[*.cs]
 
 # CS0436: Type conflicts with imported type
 dotnet_diagnostic.CS0436.severity = none
@@ -75,3 +78,6 @@ dotnet_style_null_propagation = true:suggestion
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
 dotnet_style_prefer_auto_properties = true:silent
 indent_style = tab
+
+insert_final_newline = false
+trim_trailing_whitespace = true

--- a/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
+++ b/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
@@ -334,5 +334,11 @@ public static class EventManager
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
 			new EventParameter("Interactables.Interobjects.DoorUtils.DoorVariant", false, "door"),
 			new EventParameter("System.Boolean", false, "canOpen")) },
+		{ 102, new Event(
+			new EventParameter("BanDetails", false, "banDetails"),
+			new EventParameter("BanHandler+BanType", false, "banType")) },
+		{ 103, new Event(
+			new EventParameter("System.String", false, "id"),
+			new EventParameter("BanHandler+BanType", false, "banType")) },
 	};
 }

--- a/NwPluginAPI/Core/Warhead.cs
+++ b/NwPluginAPI/Core/Warhead.cs
@@ -24,6 +24,15 @@ namespace PluginAPI.Core
 		}
 
 		/// <summary>
+		/// Gets or sets a value indicating whether the current warhead status cannot be changed by the player.
+		/// </summary>
+		public static bool IsLocked
+		{
+			get => AlphaWarheadController.Singleton.IsLocked;
+			set => AlphaWarheadController.Singleton.IsLocked = value;
+		}
+
+		/// <summary>
 		/// Gets a value indicating whether or not the warhead is detonated.
 		/// </summary>
 		public static bool IsDetonated => AlphaWarheadController.Detonated;

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -562,7 +562,7 @@ namespace PluginAPI.Enums
 		/// <remarks>
 		/// Parameters: <see cref="SpawnableTeamType"/> team.
 		/// </remarks>
-		/// 
+		///
 		TeamRespawnSelected = 70,
 
 		/// <summary>
@@ -665,7 +665,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-173 tries to start/stop brackneck speeds.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player <see cref="bool"/> activate. 
+		/// Parameters: <see cref="IPlayer"/> player <see cref="bool"/> activate.
 		/// </remarks>
 		Scp173BreakneckSpeeds = 84,
 
@@ -673,7 +673,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-173 is seen by player.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player <see cref="IPlayer"/> target. 
+		/// Parameters: <see cref="IPlayer"/> player <see cref="IPlayer"/> target.
 		/// </remarks>
 		Scp173NewObserver = 85,
 
@@ -681,7 +681,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-173 tries to snap player neck.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player <see cref="IPlayer"/> target. 
+		/// Parameters: <see cref="IPlayer"/> player <see cref="IPlayer"/> target.
 		/// </remarks>
 		Scp173SnapPlayer = 100,
 
@@ -689,7 +689,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-939 tries to create amnestic cloud.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player. 
+		/// Parameters: <see cref="IPlayer"/> player.
 		/// </remarks>
 		Scp939CreateAmnesticCloud = 86,
 
@@ -697,7 +697,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-939 tries to lunge.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="Scp939LungeState"/> state. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="Scp939LungeState"/> state.
 		/// </remarks>
 		Scp939Lunge = 87,
 
@@ -705,7 +705,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-939 tries to attack something.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="IDestructible"/> target. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="IDestructible"/> target.
 		/// </remarks>
 		Scp939Attack = 88,
 
@@ -713,7 +713,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 gains experience.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="int"/> amount, <see cref="Scp079HudTranslation"/> reason. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="int"/> amount, <see cref="Scp079HudTranslation"/> reason.
 		/// </remarks>
 		Scp079GainExperience = 89,
 
@@ -721,7 +721,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 level ups to new tier.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="int"/> tier. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="int"/> tier.
 		/// </remarks>
 		Scp079LevelUpTier = 90,
 
@@ -729,7 +729,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 tries to use tesla.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="TeslaGate"/> tesla. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="TeslaGate"/> tesla.
 		/// </remarks>
 		Scp079UseTesla = 91,
 
@@ -737,7 +737,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 lockdowns room.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room.
 		/// </remarks>
 		Scp079LockdownRoom = 92,
 
@@ -745,7 +745,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 cancels room lockdown.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room.
 		/// </remarks>
 		Scp079CancelRoomLockdown = 101,
 
@@ -753,7 +753,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 locks door.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door.
 		/// </remarks>
 		Scp079LockDoor = 93,
 
@@ -761,7 +761,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 unlocks door.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door.
 		/// </remarks>
 		Scp079UnlockDoor = 94,
 
@@ -769,7 +769,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 blackouts zone.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="FacilityZone"/> zone. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="FacilityZone"/> zone.
 		/// </remarks>
 		Scp079BlackoutZone = 95,
 
@@ -777,7 +777,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-079 blackouts room.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="RoomIdentifier"/> room.
 		/// </remarks>
 		Scp079BlackoutRoom = 96,
 
@@ -785,7 +785,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-049 resurrects body.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> target, <see cref="Ragdoll"/> body. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> target, <see cref="Ragdoll"/> body.
 		/// </remarks>
 		Scp049ResurrectBody = 97,
 
@@ -793,7 +793,7 @@ namespace PluginAPI.Enums
 		/// Event executed when SCP-049 starts resurrecting body.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> target, <see cref="Ragdoll"/> body, <see cref="bool"/> canResurrect. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> target, <see cref="Ragdoll"/> body, <see cref="bool"/> canResurrect.
 		/// </remarks>
 		Scp049StartResurrectingBody = 98,
 
@@ -801,8 +801,24 @@ namespace PluginAPI.Enums
 		/// Event executed when player tries to interact with door.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door, <see cref="bool"/> canOpen. 
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door, <see cref="bool"/> canOpen.
 		/// </remarks>
 		PlayerInteractDoor = 99,
+
+		/// <summary>
+		/// Event executed when a new ban issued and saved in the files.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="BanDetails"/> banDetails, <see cref="BanType"/> banType.
+		/// </remarks>
+		BanIssued = 102,
+
+		/// <summary>
+		/// Event executed when an existing ban is revoked and removed from the files.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="string"/> userId, <see cref="BanType"/> banType.
+		/// </remarks>
+		BanRevoked = 103,
 	}
 }

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -352,6 +352,12 @@ namespace PluginAPI.Events
 				new EventParameter(typeof(IPlayer), "player"),
 				new EventParameter(typeof(DoorVariant), "door"),
 				new EventParameter(typeof(bool), "canOpen")) },
+			{ ServerEventType.BanIssued, new Event(
+				new EventParameter(typeof(BanDetails), "banDetails"),
+				new EventParameter(typeof(BanHandler.BanType), "banType")) },
+			{ ServerEventType.BanRevoked, new Event(
+				new EventParameter(typeof(string), "id"),
+				new EventParameter(typeof(BanHandler.BanType), "banType")) },
 		};
 
 		private static bool ValidateEvent(Type[] parameters, Type[] requiredParameters)
@@ -384,7 +390,7 @@ namespace PluginAPI.Events
 			Type pluginType = plugin.GetType();
 
 			if (!AssemblyLoader.PluginToAssembly.TryGetValue(plugin, out Assembly assembly)) return;
-			
+
 			foreach(var type in assembly.GetTypes().Where(x => x.IsClass))
 			{
 				bool foundEvents = false;
@@ -423,9 +429,9 @@ namespace PluginAPI.Events
 			Type pluginType = plugin.GetType();
 
 			foreach(var handler in Events
-				.SelectMany(x => 
+				.SelectMany(x =>
 					x.Value.Invokers.Where(y => y.Key == pluginType))
-				.SelectMany(x => 
+				.SelectMany(x =>
 					x.Value.Select(y => y.Target))
 				.Distinct())
 			{
@@ -528,7 +534,7 @@ namespace PluginAPI.Events
 							Log.Debug($"Registered event &6{method.Name}&r (&6{pluginEvent.EventType}&r) in plugin &6{plugin.FullName}&r!", Log.DebugMode);
 							break;
 					}
-				}          
+				}
 			}
         }
 
@@ -611,7 +617,7 @@ namespace PluginAPI.Events
 						Log.Error($"Failed executing event &6{invoker.Method.Name}&r (&6{type}&r) in plugin &6{invoker.Plugin.FullName}&r\n{ex}");
 						continue;
 					}
-					
+
 					if (cancelled || result is null)
 						continue;
 

--- a/NwPluginAPI/Events/IEventCancellation.cs
+++ b/NwPluginAPI/Events/IEventCancellation.cs
@@ -76,7 +76,7 @@ namespace PluginAPI.Events
 		{
 			if (banReason.Length > 400)
 				throw new ArgumentOutOfRangeException(nameof(banReason), "Reason can't be longer than 400 characters.");
-			
+
 			return new PreauthCancellationData(RejectionReason.Banned, isForced, banReason, expiration: expiration);
 		}
 
@@ -90,7 +90,7 @@ namespace PluginAPI.Events
 		{
 			if (string.IsNullOrEmpty(customReason) || customReason.Length > 400)
 				throw new ArgumentOutOfRangeException(nameof(customReason), "Reason can't be null, empty or longer than 400 characters.");
-			
+
 			return new PreauthCancellationData(RejectionReason.Custom, isForced, customReason: customReason);
 		}
 
@@ -109,7 +109,7 @@ namespace PluginAPI.Events
 				case RejectionReason.Redirect:
 				case RejectionReason.Custom:
 					throw new Exception("Specified reason requires extra parameters. Please use the appropriate method.");
-				
+
 				default:
 					return new PreauthCancellationData(reason, isForced);
 			}
@@ -202,13 +202,19 @@ namespace PluginAPI.Events
 		/// <inheritdoc />
 		public bool IsCancelled { get; }
 
+		/// <summary>
+		/// Determines whether the player should be allowed to join unconditionally.
+		/// </summary>
+		public bool BypassReservedSlotsLimit { get; }
+
 		// ReSharper disable once MemberCanBePrivate.Global
 		public readonly bool HasReservedSlot;
 
-		private PlayerCheckReservedSlotCancellationData(bool isCancelled, bool hasReservedSlot)
+		private PlayerCheckReservedSlotCancellationData(bool isCancelled, bool hasReservedSlot, bool bypassReservedSlotsLimit)
 		{
 			IsCancelled = isCancelled;
 			HasReservedSlot = hasReservedSlot;
+			BypassReservedSlotsLimit = bypassReservedSlotsLimit;
 		}
 
 		/// <summary>
@@ -216,7 +222,7 @@ namespace PluginAPI.Events
 		/// </summary>
 		/// <returns>The <see cref="PlayerCheckReservedSlotCancellationData"/>.</returns>
 		public static PlayerCheckReservedSlotCancellationData LeaveUnchanged() =>
-			new PlayerCheckReservedSlotCancellationData(false, false);
+			new PlayerCheckReservedSlotCancellationData(false, false, false);
 
 		/// <summary>
 		/// Overrides a reserved slot check.
@@ -224,6 +230,12 @@ namespace PluginAPI.Events
 		/// <param name="hasReservedSlot">Indicating whether or not the player has a reserved slot.</param>
 		/// <returns>The <see cref="PlayerCheckReservedSlotCancellationData"/>.</returns>
 		public static PlayerCheckReservedSlotCancellationData Override(bool hasReservedSlot) =>
-			new PlayerCheckReservedSlotCancellationData(true, hasReservedSlot);
+			new PlayerCheckReservedSlotCancellationData(true, hasReservedSlot, false);
+
+		/// <summary>
+		/// Bypasses the check of free reserved slots on the server and allows the connection unconditionally.
+		/// </summary>
+		/// <returns></returns>
+		public static PlayerCheckReservedSlotCancellationData BypassCheck() => new PlayerCheckReservedSlotCancellationData(true, true, true);
 	}
 }

--- a/NwPluginAPI/Helpers/Paths.cs
+++ b/NwPluginAPI/Helpers/Paths.cs
@@ -19,12 +19,12 @@ namespace PluginAPI.Helpers
 		/// <summary>
 		/// Gets the paths to global plugins and dependencies.
 		/// </summary>
-		public static PluginDirectory GlobalPlugins { get; internal set; }
+		public static PluginDirectory GlobalPlugins { get; private set; }
 
 		/// <summary>
 		/// Gets the paths to this server port's plugins and dependencies.
 		/// </summary>
-		public static PluginDirectory LocalPlugins { get; internal set; }
+		public static PluginDirectory LocalPlugins { get; private set; }
 
 		/// <summary>
 		/// Gets the path to the server's config settings.
@@ -57,17 +57,19 @@ namespace PluginAPI.Helpers
 		public static string Dependencies { get; private set; }
 
 		/// <summary>
-		/// Intializes all the paths.
+		/// Initializes all the paths.
 		/// </summary>
 		internal static void Setup()
 		{
-			AppData = GetHosterPolicy() ? 
-				"AppData" : 
+			AppData = GetHosterPolicy() ?
+				"AppData" :
 				Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
 
 			if (!Directory.Exists(AppData)) Directory.CreateDirectory(AppData);
 
 			SecretLab = GetDirectory(AppData, "SCP Secret Laboratory");
+
+			Configs = FileManager.GetAppFolder(true, true);
 
 			PluginAPI = GetDirectory(SecretLab, "PluginAPI");
 			Plugins = GetDirectory(PluginAPI, "plugins");
@@ -76,7 +78,7 @@ namespace PluginAPI.Helpers
 			LocalPlugins = new PluginDirectory(GetDirectory(Plugins, Server.Port.ToString()));
 		}
 
-		internal static bool GetHosterPolicy()
+		private static bool GetHosterPolicy()
 		{
 			if (!File.Exists("hoster_policy.txt"))
 				return false;

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -266,5 +266,17 @@
 		{
 			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) teleported player &6{target.Nickname}&r (&6{target.UserId}&r) to pocket dimension as SCP-106");
 		}
+
+		[PluginEvent(ServerEventType.BanIssued)]
+		public void OnBanIssued(BanDetails banDetails, BanHandler.BanType banType)
+		{
+			Log.Info($"UserID {banDetails.Id} of type {banType} has been banned by {banDetails.Issuer}.");
+		}
+
+		[PluginEvent(ServerEventType.BanRevoked)]
+		public void OnBanRevoked(string id, BanHandler.BanType banType)
+		{
+			Log.Info($"ID {id} of type {banType} has been unbanned.");
+		}
 	}
 }


### PR DESCRIPTION
 - Added ban storage events: `BanIssued` and `BanRevoked` (Resolves #79).
 - Added `BypassCheck()` to `PlayerCheckReservedSlotCancellationData` (Related to #78).
 - Fixed `Path.Configs` (Related to #62).
 - Added `Warhead.IsLocked` (Resolves #74).
 - Edited `.editorconfig`.