### PR TITLE
Removed redundant and unused Paths

### DIFF
--- a/NwPluginAPI/Helpers/Paths.cs
+++ b/NwPluginAPI/Helpers/Paths.cs
@@ -12,11 +12,6 @@ namespace PluginAPI.Helpers
 	public static class Paths
 	{
 		/// <summary>
-		/// Gets the path to global config folder.
-		/// </summary>
-		public static string Global { get; private set; }
-
-		/// <summary>
 		/// Gets the paths to global plugins and dependencies.
 		/// </summary>
 		public static PluginDirectory GlobalPlugins { get; private set; }
@@ -50,11 +45,6 @@ namespace PluginAPI.Helpers
 		/// Gets the path to the "Plugins" folder, located inside the "Plugin API" folder.
 		/// </summary>
 		public static string Plugins { get; private set; }
-
-		/// <summary>
-		/// Gets the path to the "Dependencies" folder, located inside the "Plugins" folder.
-		/// </summary>
-		public static string Dependencies { get; private set; }
 
 		/// <summary>
 		/// Initializes all the paths.

--- a/NwPluginAPI/Loader/Features/PluginDirectory.cs
+++ b/NwPluginAPI/Loader/Features/PluginDirectory.cs
@@ -5,7 +5,7 @@ namespace PluginAPI.Loader.Features
 	/// <summary>
     /// Contains the paths containing plugins and dependencies.
     /// </summary>
-    public struct PluginDirectory
+    public readonly struct PluginDirectory
     {
 		/// <summary>
 		/// Initializes a new instance of the <see cref="PluginDirectory"/> struct.
@@ -14,18 +14,17 @@ namespace PluginAPI.Loader.Features
 		public PluginDirectory(string containingFolder)
 		{
 			Plugins = containingFolder;
-
 			Dependencies = Paths.GetDirectory(Plugins, "dependencies");
 		}
 
 		/// <summary>
 		/// Gets or sets the dependencies folder.
 		/// </summary>
-		public string Dependencies { get; set; }
+		public readonly string Dependencies;
 
 		/// <summary>
 		/// Gets or sets the plugins folder.
 		/// </summary>
-		public string Plugins { get; set; }
-	}
+		public readonly string Plugins;
+    }
 }


### PR DESCRIPTION
Removed `Paths.Global` (unused and not planned to be used) and `Paths.Dependencies` (`Paths.LocalPlugins.Dependencies` should be used instead).

Resolves #62.