### PR TITLE
A few minor tweaks for QoL

### DIFF
--- a/NwPluginAPI/Core/PluginHandler.cs
+++ b/NwPluginAPI/Core/PluginHandler.cs
@@ -19,13 +19,14 @@ namespace PluginAPI.Core
 	/// </summary>
 	public class PluginHandler
 	{
-		private static readonly string UnknownName = "Unknown";
-		private static readonly string UnknownVersion = "0.0.0";
+		private const string UnknownName = "Unknown";
+		private const string UnknownVersion = "0.0.0";
 
 		private readonly string _pluginDirectory;
 		private readonly string _mainConfigPath;
 
         private readonly PluginEntryPoint _entryInfo;
+        private string _pluginVersion;
 
         private readonly MethodInfo _entryPoint;
         private readonly MethodInfo _onUnload;
@@ -62,7 +63,30 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Gets the version of the plugin.
 		/// </summary>
-		public string PluginVersion => _entryInfo?.Version ?? UnknownVersion;
+		public string PluginVersion
+		{
+			get
+			{
+				if (string.IsNullOrEmpty(_pluginVersion))
+				{
+					if (_entryInfo is not null)
+					{
+						if (!string.IsNullOrEmpty(_entryInfo.Version))
+						{
+							_pluginVersion = _entryInfo.Version;
+
+							return _pluginVersion;
+						}
+					}
+
+					_pluginVersion =
+						Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+							.InformationalVersion ?? UnknownVersion;
+				}
+
+				return _pluginVersion;
+			}
+		}
 
 		/// <summary>
 		/// Gets the description of the plugin.
@@ -171,7 +195,7 @@ namespace PluginAPI.Core
 				File.WriteAllText(targetPath, YamlParser.Serializer.Serialize(config));
 
 				Log.Debug($"Loaded config file for &2{PluginName}&r.", Log.DebugMode);
-			}	
+			}
 		}
 		/// <summary>
 		/// Loads the default plugin config.

--- a/NwPluginAPI/NwPluginAPI.csproj
+++ b/NwPluginAPI/NwPluginAPI.csproj
@@ -34,6 +34,7 @@
 		<Title>Northwood.PluginAPI</Title>
 		<Copyright>Copyright by Hubert Moszka Northwood, 2022</Copyright>
 		<PackageVersion>12.0.0-rc.3</PackageVersion>
+		<LangVersion>default</LangVersion>
 	</PropertyGroup>
 
 	<PropertyGroup>


### PR DESCRIPTION
- Update langversion for NwPluginAPI (No reason to use 7.3 over latest)

- Allow for null/empty version strings to be passed via PluginEntryPoint attribute to fill in the version in the assembly itself.
      Note: This is important for projects that compile multiple DLLs using a shared .props file to define the assembly version. With the current system, they have to still manually update the version string given to PluginAPI for each assembly that has an entrypoint attribute, the new way will allow them to simply pass `null` or `""` as the version string, and the API will get the version from the assembly itself instead. (used private backing field so that reflection is only needed the first time the version string getter is called, rather than every time)

- Replaced "static readonly" with "const" because they are the same thing.