### PR TITLE
Scp096 Events

### DIFF
--- a/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
+++ b/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
@@ -401,5 +401,26 @@ public static class EventManager
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
 			new EventParameter("Scp914.Scp914KnobSetting", false, "knobSetting"),
 			new EventParameter("UnityEngine.Vector3", false, "outPosition")) },
+		{ 115, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("PlayerRoles.PlayableScps.Scp079.Cameras.Scp079Camera", false, "camera")) },
+		{ 116, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "target"),
+			new EventParameter("System.Boolean", false, "isForLook")) },
+		{ 117, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("System.Boolean", false, "clearTime"),
+			new EventParameter("System.Single", false, "enragedTimeLeft")) },
+		{ 118, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+		{ 119, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+		{ 120, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("Interactables.Interobjects.PryableDoor", false, "gateDoor")) },
+		{ 121, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("Interactables.Interobjects.DoorUtils.DoorVariant", false, "door")) },
 	};
 }

--- a/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
+++ b/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
@@ -410,17 +410,18 @@ public static class EventManager
 			new EventParameter("System.Boolean", false, "isForLook")) },
 		{ 117, new Event(
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
-			new EventParameter("System.Boolean", false, "clearTime"),
-			new EventParameter("System.Single", false, "enragedTimeLeft")) },
+			new EventParameter("System.Single", false, "initialDuration")) },
 		{ 118, new Event(
-			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("PlayerRoles.PlayableScps.Scp096.Scp096RageState", false, "rageState")) },
 		{ 119, new Event(
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
 		{ 120, new Event(
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
 			new EventParameter("Interactables.Interobjects.PryableDoor", false, "gateDoor")) },
 		{ 121, new Event(
-			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
-			new EventParameter("Interactables.Interobjects.DoorUtils.DoorVariant", false, "door")) },
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+		{ 122, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
 	};
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -961,5 +961,53 @@ namespace PluginAPI.Enums
 		/// </remarks>
 		Scp079CameraChanged = 115,
 
+		/// <summary>
+		/// Executes when a player looks at SCP-096.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> target, <see cref="bool"/> isForLooking.
+		/// </remarks>
+		Scp096AddingTarget = 116,
+
+		/// <summary>
+		/// Executed when a SCP096 gets angered.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="bool"/> clearTime, <see cref="float"/> enragedTimeLeft
+		/// </remarks>
+		Scp096Enraging = 117,
+
+		/// <summary>
+		/// Executed when SCP-096 calms down.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player.
+		/// </remarks>
+		Scp096CalmingDown = 118,
+
+		/// <summary>
+		/// Executed when SCP-096 charges.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player.
+		/// </remarks>
+		Scp096Charging = 119,
+
+		/// <summary>
+		/// Executed when SCP-096 begins prying a gate.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="PryableDoor"/> gateDoor.
+		/// </remarks>
+		Scp096PryingGate = 120,
+
+		/// <summary>
+		/// Executed when SCP-096 tries not to cry.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door.
+		/// </remarks>
+		/// Door can be null if SCP-096 is crying on a wall
+		ScpTryNotCry = 121,
 	}
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -1,5 +1,6 @@
 using Footprinting;
 using PlayerRoles.PlayableScps.Scp079.Cameras;
+using PlayerRoles.PlayableScps.Scp096;
 using PluginAPI.Events;
 
 namespace PluginAPI.Enums
@@ -973,17 +974,17 @@ namespace PluginAPI.Enums
 		/// Executed when a SCP096 gets angered.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="bool"/> clearTime, <see cref="float"/> enragedTimeLeft
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="float"/> initialDuration.
 		/// </remarks>
 		Scp096Enraging = 117,
 
 		/// <summary>
-		/// Executed when SCP-096 calms down.
+		/// Executed when SCP-096 changes state.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player.
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="Scp096RageState"/> rageState.
 		/// </remarks>
-		Scp096CalmingDown = 118,
+		Scp096ChangeState = 118,
 
 		/// <summary>
 		/// Executed when SCP-096 charges.
@@ -1005,9 +1006,17 @@ namespace PluginAPI.Enums
 		/// Executed when SCP-096 tries not to cry.
 		/// </summary>
 		/// <remarks>
-		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door.
+		/// Parameters: <see cref="IPlayer"/> player
 		/// </remarks>
 		/// Door can be null if SCP-096 is crying on a wall
 		Scp096TryNotCry = 121,
+
+		/// <summary>
+		/// Executed when SCP-096 cancels its TryToNotCry ability.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player
+		/// </remarks>
+		Scp096StartCrying = 122,
 	}
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -1008,7 +1008,6 @@ namespace PluginAPI.Enums
 		/// <remarks>
 		/// Parameters: <see cref="IPlayer"/> player
 		/// </remarks>
-		/// Door can be null if SCP-096 is crying on a wall
 		Scp096TryNotCry = 121,
 
 		/// <summary>

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -1008,6 +1008,6 @@ namespace PluginAPI.Enums
 		/// Parameters: <see cref="IPlayer"/> player, <see cref="DoorVariant"/> door.
 		/// </remarks>
 		/// Door can be null if SCP-096 is crying on a wall
-		ScpTryNotCry = 121,
+		Scp096TryNotCry = 121,
 	}
 }

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -645,6 +645,37 @@ namespace PluginAPI.Events
 					new EventParameter(typeof(IPlayer), "player"),
 					new EventParameter(typeof(Scp079Camera), "camera"))
 			},
+			{
+				ServerEventType.Scp096AddingTarget, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(IPlayer), "target"),
+					new EventParameter(typeof(bool), "isForLook")
+					)
+			},
+			{
+				ServerEventType.Scp096Enraging, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(bool), "clearTime"),
+					new EventParameter(typeof(float), "enragedTimeLeft"))
+			},
+			{
+				ServerEventType.Scp096CalmingDown, new Event(
+					new EventParameter(typeof(IPlayer), "player"))
+			},
+			{
+				ServerEventType.Scp096Charging, new Event(
+					new EventParameter(typeof(IPlayer), "player"))
+			},
+			{
+				ServerEventType.Scp096PryingGate, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(PryableDoor), "gateDoor"))
+			},
+			{
+				ServerEventType.ScpTryNotCry, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(DoorVariant), "door"))
+			}
 		};
 
 		private static bool ValidateEvent(Type[] parameters, Type[] requiredParameters)

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -1,5 +1,6 @@
 using Footprinting;
 using PlayerRoles.PlayableScps.Scp079.Cameras;
+using PlayerRoles.PlayableScps.Scp096;
 
 namespace PluginAPI.Events
 {
@@ -655,12 +656,12 @@ namespace PluginAPI.Events
 			{
 				ServerEventType.Scp096Enraging, new Event(
 					new EventParameter(typeof(IPlayer), "player"),
-					new EventParameter(typeof(bool), "clearTime"),
-					new EventParameter(typeof(float), "enragedTimeLeft"))
+					new EventParameter(typeof(float), "initialDuration"))
 			},
 			{
-				ServerEventType.Scp096CalmingDown, new Event(
-					new EventParameter(typeof(IPlayer), "player"))
+				ServerEventType.Scp096ChangeState, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(Scp096RageState), "rageState"))
 			},
 			{
 				ServerEventType.Scp096Charging, new Event(
@@ -673,8 +674,11 @@ namespace PluginAPI.Events
 			},
 			{
 				ServerEventType.Scp096TryNotCry, new Event(
-					new EventParameter(typeof(IPlayer), "player"),
-					new EventParameter(typeof(DoorVariant), "door"))
+					new EventParameter(typeof(IPlayer), "player"))
+			},
+			{
+				ServerEventType.Scp096StartCrying, new Event(
+					new EventParameter(typeof(IPlayer), "player"))
 			}
 		};
 

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -672,7 +672,7 @@ namespace PluginAPI.Events
 					new EventParameter(typeof(PryableDoor), "gateDoor"))
 			},
 			{
-				ServerEventType.ScpTryNotCry, new Event(
+				ServerEventType.Scp096TryNotCry, new Event(
 					new EventParameter(typeof(IPlayer), "player"),
 					new EventParameter(typeof(DoorVariant), "door"))
 			}

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -275,7 +275,7 @@ namespace TemplatePlugin
 		[PluginEvent(ServerEventType.Scp096AddingTarget)]
 		public void OnScp096AddTarget(MyPlayer player, MyPlayer target, bool isForLooking)
 		{
-			Log.Info($"Player &6{target.Nickname}&r (&6{player.UserId}&r) {(isForLooking ? "look" : "shoot")}  player &6{player.Nickname}&r (&6{player.UserId}&r) and was added to the SCP-096 target list");
+			Log.Info($"Player &6{target.Nickname}&r (&6{target.UserId}&r) {(isForLooking ? "look" : "shoot")}  player &6{player.Nickname}&r (&6{player.UserId}&r) and was added to the SCP-096 target list");
 		}
 
 		[PluginEvent(ServerEventType.Scp096Enraging)]

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -302,6 +302,7 @@ namespace TemplatePlugin
 			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) breached the gate {gate.name}");
 		}
 
+		[PluginEvent(ServerEventType.Scp096TryNotCry)]
 		public void OnScp096TryingNotCry(MyPlayer player, DoorVariant door)
 		{
 			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry in a {(door is null ? "door" : "wall")}");

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -1,4 +1,5 @@
-﻿using MapGeneration.Distributors;
+﻿using Interactables.Interobjects;
+using MapGeneration.Distributors;
 using Scp914;
 
 namespace TemplatePlugin
@@ -269,6 +270,41 @@ namespace TemplatePlugin
 		public void OnScp106TeleportPlayer(MyPlayer player, MyPlayer target)
 		{
 			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) teleported player &6{target.Nickname}&r (&6{target.UserId}&r) to pocket dimension as SCP-106");
+		}
+
+		[PluginEvent(ServerEventType.Scp096AddingTarget)]
+		public void OnScp096AddTarget(MyPlayer player, MyPlayer target, bool isForLooking)
+		{
+			Log.Info($"Player &6{target.Nickname}&r (&6{player.UserId}&r) {(isForLooking ? "look" : "shoot")}  player &6{player.Nickname}&r (&6{player.UserId}&r) and was added to the SCP-096 target list");
+		}
+
+		[PluginEvent(ServerEventType.Scp096Enraging)]
+		public void OnScp096Enrage(MyPlayer player, bool clearTime, float enragedTimeLeft)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) went into a state of rage for {enragedTimeLeft} seconds");
+		}
+
+		[PluginEvent(ServerEventType.Scp096CalmingDown)]
+		public void OnScp096CalmDown(MyPlayer player)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) calm down as SCP-096");
+		}
+
+		[PluginEvent(ServerEventType.Scp096Charging)]
+		public void OnScp096Charge(MyPlayer player)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) uses its charging ability as SCP-096");
+		}
+
+		[PluginEvent(ServerEventType.Scp096PryingGate)]
+		public void OnScp096PryGate(MyPlayer player, PryableDoor gate)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) breached the gate {gate.name}");
+		}
+
+		public void OnScp096TryingNotCry(MyPlayer player, DoorVariant door)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry in a {(door is null ? "door" : "wall")}");
 		}
 
 		[PluginEvent(ServerEventType.BanIssued)]

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -1,6 +1,7 @@
 ﻿using Interactables.Interobjects;
 ﻿using MapGeneration.Distributors;
 using PlayerRoles.PlayableScps.Scp079.Cameras;
+using PlayerRoles.PlayableScps.Scp096;
 using Scp914;
 
 namespace TemplatePlugin
@@ -286,15 +287,15 @@ namespace TemplatePlugin
 		}
 
 		[PluginEvent(ServerEventType.Scp096Enraging)]
-		public void OnScp096Enrage(MyPlayer player, bool clearTime, float enragedTimeLeft)
+		public void OnScp096Enrage(MyPlayer player, float initialDuration)
 		{
-			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) went into a state of rage for {enragedTimeLeft} seconds");
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) went into a state of rage for {initialDuration} seconds");
 		}
 
-		[PluginEvent(ServerEventType.Scp096CalmingDown)]
-		public void OnScp096CalmDown(MyPlayer player)
+		[PluginEvent(ServerEventType.Scp096ChangeState)]
+		public void OnScp096CalmDown(MyPlayer player, Scp096RageState rageState)
 		{
-			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) calm down as SCP-096");
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) changed its state to {rageState} as SCP-096");
 		}
 
 		[PluginEvent(ServerEventType.Scp096Charging)]
@@ -310,9 +311,15 @@ namespace TemplatePlugin
 		}
 
 		[PluginEvent(ServerEventType.Scp096TryNotCry)]
-		public void OnScp096TryingNotCry(MyPlayer player, DoorVariant door)
+		public void OnScp096TryingNotCry(MyPlayer player)
 		{
-			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry in a {(door is null ? "wall" : "door")}");
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry");
+		}
+
+		[PluginEvent(ServerEventType.Scp096StartCrying)]
+		public void OnScp096StartCrying(MyPlayer player)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) cancel his TryToNotCry ability");
 		}
 
 		[PluginEvent(ServerEventType.BanIssued)]

--- a/TemplatePlugin/EventHandlers.cs
+++ b/TemplatePlugin/EventHandlers.cs
@@ -305,7 +305,7 @@ namespace TemplatePlugin
 		[PluginEvent(ServerEventType.Scp096TryNotCry)]
 		public void OnScp096TryingNotCry(MyPlayer player, DoorVariant door)
 		{
-			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry in a {(door is null ? "door" : "wall")}");
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is trying not to cry in a {(door is null ? "wall" : "door")}");
 		}
 
 		[PluginEvent(ServerEventType.BanIssued)]

--- a/TemplatePlugin/MainClass.cs
+++ b/TemplatePlugin/MainClass.cs
@@ -265,7 +265,9 @@ namespace TemplatePlugin
 		[PluginEvent(ServerEventType.PlayerKicked)]
 		void OnPlayerKicked(MyPlayer plr, ICommandSender issuer, string reason)
 		{
-			Log.Info($"Player &6{plr.Nickname}&r (&6{plr.UserId}&r) kicked from server by &6{issuer.Nickname}&r (&6{issuer.UserId}&r) with reason &6{reason}&r.");
+			var playerIssuer = Player.Get(issuer);
+
+			Log.Info($"Player &6{plr.Nickname}&r (&6{plr.UserId}&r) kicked from server by &6{playerIssuer.Nickname}&r (&6{playerIssuer.UserId}&r) with reason &6{reason}&r.");
 		}
 
 		[PluginEvent(ServerEventType.PlayerOpenGenerator)]


### PR DESCRIPTION
* New event ``Scp096AddingTarget`` params: IPlayer player, IPlayer, target, bool isForLook
This last one bool is so that the event is also executed in AddTargetOnDamage(DamageHandlerBase obj)

* New event ``Scp096Enraging`` params: IPlayer player,  float initialDuration

* New event ``Scp096ChangeState `` params: IPlayer player, Scp096RageState rageState

* New event ``Scp096PryingGate`` params: IPlayer player, PryableDoor gateDoor

* New event ``Scp096TryNotCry`` params: IPlayer player

* New event ``Scp096StartCrying `` params: IPlayer player
   Executed when SCP-096 stop his TryToNotCry ability