### PR TITLE
Player.cs & Server.cs changes

### DIFF
--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -673,9 +673,9 @@ namespace PluginAPI.Core
 		public IReadOnlyCollection<ItemBase> Items => ReferenceHub.inventory.UserInventory.Items.Values;
 
 		/// <summary>
-		/// Get player ammo.
+		/// Get player ammo bag.
 		/// </summary>
-		public Dictionary<ItemType, ushort> Ammo => ReferenceHub.inventory.UserInventory.ReserveAmmo;
+		public Dictionary<ItemType, ushort> AmmoBag => ReferenceHub.inventory.UserInventory.ReserveAmmo;
 
 		/// <summary>
 		/// Get or set server role color.
@@ -699,7 +699,7 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Gets the player unit name.
 		/// </summary>
-		public string UnitName => ReferenceHub.roleManager.CurrentRole is HumanRole humanRole ? humanRole.UnitName : string.Empty;
+		public string UnitName => ReferenceHub.roleManager.CurrentRole is HumanRole humanRole ? humanRole.UnitName : null;
 
 		/// <summary>
 		/// Get if player has reserved slot.
@@ -815,7 +815,7 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Gets if the player is SCP.
 		/// </summary>
-		public bool IsScp => Role.GetTeam() is Team.SCPs;
+		public bool IsSCP => Role.GetTeam() is Team.SCPs;
 
 		/// <summary>
 		/// Gets whether or not the player is human.
@@ -830,7 +830,7 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Gets whether or not the player is Chaos Insurgency forces.
 		/// </summary>
-		public bool IsCHI => Role.GetTeam() is Team.ChaosInsurgency;
+		public bool IsChaos => Role.GetTeam() is Team.ChaosInsurgency;
 
 		/// <summary>
 		/// Gets whether or not the player is tutorial.

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -673,14 +673,9 @@ namespace PluginAPI.Core
 		public IReadOnlyCollection<ItemBase> Items => ReferenceHub.inventory.UserInventory.Items.Values;
 
 		/// <summary>
-		/// Get or set player group.
+		/// Get player ammo.
 		/// </summary>
-		public UserGroup Group
-		{
-			// serverRoles.Group is a private field
-			get => ReferenceHub.serverRoles.Group;
-			set => ReferenceHub.serverRoles.SetGroup(value, false);
-		}
+		public Dictionary<ItemType, ushort> Ammo => ReferenceHub.inventory.UserInventory.ReserveAmmo;
 
 		/// <summary>
 		/// Get or set server role color.
@@ -700,6 +695,7 @@ namespace PluginAPI.Core
 			set => ReferenceHub.serverRoles.SetText(value);
 		}
 
+
 		/// <summary>
 		/// Gets the player unit name.
 		/// </summary>
@@ -714,12 +710,6 @@ namespace PluginAPI.Core
 		/// Gets player velocity.
 		/// </summary>
 		public Vector3 Velocity => ReferenceHub.GetVelocity();
-
-		/// <summary>
-		/// Gets player command sender.
-		/// </summary>
-		// _sender is a private fild.
-		public PlayerCommandSender CommandSender => ReferenceHub.queryProcessor._sender;
 
 		/// <summary>
 		/// Gets player <see cref="VoiceModule"/>
@@ -1003,36 +993,6 @@ namespace PluginAPI.Core
 		}
 
 		/// <summary>
-		/// Sets the player server role. why group is private....
-		/// </summary>
-		/// <param name="name">Name of server role to set.</param>
-		/// <param name="group">Group to be set.</param>
-		public void SetServerRole(string name, UserGroup group)
-		{
-			// _groups is a private fild
-			if (ServerStatic.GetPermissionsHandler()._groups.ContainsKey(name))
-			{
-				ServerStatic.GetPermissionsHandler()._groups[name].BadgeColor = group.BadgeColor;
-				ServerStatic.GetPermissionsHandler()._groups[name].BadgeText = name;
-				ServerStatic.GetPermissionsHandler()._groups[name].HiddenByDefault = !group.Cover;
-				ServerStatic.GetPermissionsHandler()._groups[name].Cover = group.Cover;
-
-				ReferenceHub.serverRoles.SetGroup(ServerStatic.GetPermissionsHandler()._groups[name], false, false, group.Cover);
-			}
-			else
-			{
-				ServerStatic.GetPermissionsHandler()._groups.Add(name, group);
-
-				ReferenceHub.serverRoles.SetGroup(group, false, false, group.Cover);
-			}
-
-			if (ServerStatic.GetPermissionsHandler()._members.ContainsKey(UserId))
-				ServerStatic.GetPermissionsHandler()._members[UserId] = name;
-			else
-				ServerStatic.GetPermissionsHandler()._members.Add(UserId, name);
-		}
-
-		/// <summary>
 		/// Clears displayed broadcast(s).
 		/// </summary>
 		public void ClearBroadcasts() => Server.Instance.GetComponent<Broadcast>().TargetClearElements(ReferenceHub.characterClassManager.connectionToClient);
@@ -1217,6 +1177,15 @@ namespace PluginAPI.Core
 					ReferenceHub.inventory.ServerRemoveItem(inventory.Items.ElementAt(0).Key, null);
 				}
 			}
+		}
+
+		/// <summary>
+		/// Set player <see cref="UserGroup"/>
+		/// </summary>
+		/// <param name="group">UserGroup to set</param>
+		public void SetGroup(UserGroup group)
+		{
+			ReferenceHub.serverRoles.SetGroup(group, false);
 		}
 
 		/// <summary>

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -989,13 +989,13 @@ namespace PluginAPI.Core
 		{
 			if (shouldClearPrevious) ClearBroadcasts();
 
-			Server.Instance.GetComponent<Broadcast>().TargetAddElement(ReferenceHub.characterClassManager.connectionToClient, message, duration, type);
+			Server.Broadcast.TargetAddElement(ReferenceHub.characterClassManager.connectionToClient, message, duration, type);
 		}
 
 		/// <summary>
 		/// Clears displayed broadcast(s).
 		/// </summary>
-		public void ClearBroadcasts() => Server.Instance.GetComponent<Broadcast>().TargetClearElements(ReferenceHub.characterClassManager.connectionToClient);
+		public void ClearBroadcasts() => Server.Broadcast.TargetClearElements(ReferenceHub.characterClassManager.connectionToClient);
 
 		/// <summary>
 		/// Sends a console message to the player's console.

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -670,7 +670,7 @@ namespace PluginAPI.Core
 		/// </summary>
 		public UserGroup Group
 		{
-			// Set group is not private but get group yes !?
+			// serverRoles.Group is a private field
 			get => ReferenceHub.serverRoles.Group;
 			set => ReferenceHub.serverRoles.SetGroup(value, false);
 		}
@@ -1001,6 +1001,7 @@ namespace PluginAPI.Core
 		/// <param name="group">Group to be set.</param>
 		public void SetServerRole(string name, UserGroup group)
 		{
+			// _groups is a private fild
 			if (ServerStatic.GetPermissionsHandler()._groups.ContainsKey(name))
 			{
 				ServerStatic.GetPermissionsHandler()._groups[name].BadgeColor = group.BadgeColor;

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -1,4 +1,3 @@
-
 namespace PluginAPI.Core
 {
 	using System;
@@ -29,6 +28,7 @@ namespace PluginAPI.Core
 	using InventorySystem.Items.Pickups;
 	using PluginAPI.Core.Items;
 	using PlayerRoles.Voice;
+	using RemoteAdmin;
 
 	/// <summary>
 	/// Represents a player connected to server.
@@ -715,10 +715,11 @@ namespace PluginAPI.Core
 		/// </summary>
 		public Vector3 Velocity => ReferenceHub.GetVelocity();
 
-		/*/// <summary>
-		/// Gets player command sender. Oh no field is private
+		/// <summary>
+		/// Gets player command sender.
 		/// </summary>
-		public PlayerCommandSender CommandSender => ReferenceHub.queryProcessor._sender;*/
+		// _sender is a private fild.
+		public PlayerCommandSender CommandSender => ReferenceHub.queryProcessor._sender;
 
 		/// <summary>
 		/// Gets player <see cref="VoiceModule"/>

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -1,3 +1,6 @@
+using PlayerRoles.PlayableScps.Scp079;
+using PlayerRoles.PlayableScps.Scp079.Pinging;
+using PlayerRoles.PlayableScps.Scp096;
 using PlayerRoles.Voice;
 using RemoteAdmin;
 
@@ -572,6 +575,14 @@ namespace PluginAPI.Core
 			get => ReferenceHub.GetRoleId();
 			set => ReferenceHub.roleManager.ServerSetRole(value, RoleChangeReason.RemoteAdmin);
 		}
+
+		/// <summary>
+		/// Gets player <see cref="PlayerRoleBase"/>
+		/// <remarks>
+		/// It is useful to use for example (RoleBase as Scp096Role)
+		/// </remarks>
+		/// </summary>
+		public PlayerRoleBase RoleBase => ReferenceHub.roleManager.CurrentRole;
 
 		/// <summary>
 		/// Gets or sets the player's custom info.

--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -1,8 +1,3 @@
-using PlayerRoles.PlayableScps.Scp079;
-using PlayerRoles.PlayableScps.Scp079.Pinging;
-using PlayerRoles.PlayableScps.Scp096;
-using PlayerRoles.Voice;
-using RemoteAdmin;
 
 namespace PluginAPI.Core
 {
@@ -33,6 +28,7 @@ namespace PluginAPI.Core
 	using CommandSystem;
 	using InventorySystem.Items.Pickups;
 	using PluginAPI.Core.Items;
+	using PlayerRoles.Voice;
 
 	/// <summary>
 	/// Represents a player connected to server.

--- a/NwPluginAPI/Core/Server.cs
+++ b/NwPluginAPI/Core/Server.cs
@@ -1,3 +1,7 @@
+using System;
+using CustomPlayerEffects;
+using UnityEngine;
+
 namespace PluginAPI.Core
 {
 	using CommandSystem;
@@ -66,6 +70,11 @@ namespace PluginAPI.Core
 		}
 
 		/// <summary>
+		/// Get the amount of players connected to the server.
+		/// </summary>
+		public static int PlayersConnected => Player.Count;
+
+		/// <summary>
 		/// Gets or sets the maximum amount of players online at the same time.
 		/// </summary>
 		public static int MaxPlayers
@@ -81,6 +90,48 @@ namespace PluginAPI.Core
 		{
 			get => CustomNetworkManager.reservedSlots;
 			set => CustomNetworkManager.reservedSlots = value;
+		}
+
+		/// <summary>
+		/// Get server <see cref="PermissionsHandler"/>
+		/// </summary>
+		public static PermissionsHandler PermissionsHandler => ServerStatic.GetPermissionsHandler();
+
+		/// <summary>
+		/// Get actual ticks per second of the server.
+		/// </summary>
+		public static double Tps => Math.Round(1f / Time.smoothDeltaTime);
+
+		/// <summary>
+		/// Get actual frames of the server.
+		/// </summary>
+		public static double Frames => Math.Round(1f / Time.deltaTime);
+
+		/// <summary>
+		/// Get or set server spawn protection time.
+		/// </summary>
+		public static float SpawnProtectTime
+		{
+			get => SpawnProtected.SpawnDuration;
+			set => SpawnProtected.SpawnDuration = value;
+		}
+
+		/// <summary>
+		/// Get or set if server is heavily modded.
+		/// </summary>
+		public static bool IsHeavilyModded
+		{
+			get => CustomNetworkManager.HeavilyModded;
+			set => CustomNetworkManager.HeavilyModded = value;
+		}
+
+		/// <summary>
+		/// Get or set server has whitelist enabled.
+		/// </summary>
+		public static bool IsWhitelisted
+		{
+			get => ServerConsole.WhiteListEnabled;
+			set => ServerConsole.WhiteListEnabled = value;
 		}
 
 #region Ban System

--- a/NwPluginAPI/Core/Server.cs
+++ b/NwPluginAPI/Core/Server.cs
@@ -92,6 +92,8 @@ namespace PluginAPI.Core
 			set => CustomNetworkManager.reservedSlots = value;
 		}
 
+		public static Broadcast Broadcast => Broadcast.Singleton;
+
 		/// <summary>
 		/// Get server <see cref="PermissionsHandler"/>
 		/// </summary>

--- a/NwPluginAPI/Core/Server.cs
+++ b/NwPluginAPI/Core/Server.cs
@@ -72,7 +72,7 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Get the amount of players connected to the server.
 		/// </summary>
-		public static int PlayersConnected => Player.Count;
+		public static int PlayerCount => Player.Count;
 
 		/// <summary>
 		/// Gets or sets the maximum amount of players online at the same time.
@@ -100,17 +100,12 @@ namespace PluginAPI.Core
 		/// <summary>
 		/// Get actual ticks per second of the server.
 		/// </summary>
-		public static double Tps => Math.Round(1f / Time.smoothDeltaTime);
+		public static double TPS => Math.Round(1f / Time.smoothDeltaTime);
 
 		/// <summary>
-		/// Get actual frames of the server.
+		/// Get or set server spawn protection duration.
 		/// </summary>
-		public static double Frames => Math.Round(1f / Time.deltaTime);
-
-		/// <summary>
-		/// Get or set server spawn protection time.
-		/// </summary>
-		public static float SpawnProtectTime
+		public static float SpawnProtectDuration
 		{
 			get => SpawnProtected.SpawnDuration;
 			set => SpawnProtected.SpawnDuration = value;
@@ -125,16 +120,7 @@ namespace PluginAPI.Core
 			set => CustomNetworkManager.HeavilyModded = value;
 		}
 
-		/// <summary>
-		/// Get or set server has whitelist enabled.
-		/// </summary>
-		public static bool IsWhitelisted
-		{
-			get => ServerConsole.WhiteListEnabled;
-			set => ServerConsole.WhiteListEnabled = value;
-		}
-
-#region Ban System
+		#region Ban System
 
 		/// <summary>
 		/// Bans a player from the server.

--- a/NwPluginAPI/Core/Zones/FacilityRoom.cs
+++ b/NwPluginAPI/Core/Zones/FacilityRoom.cs
@@ -149,8 +149,9 @@ namespace PluginAPI.Core.Zones
 			Zone = zone;
 			Identifier = room;
 
-			if(room.GetComponentInChildren<FlickerableLightController>())
-				Lights = new RoomLight(room.GetComponentInChildren<FlickerableLightController>());
+			var lightController = room.GetComponentInChildren<FlickerableLightController>();
+			if(lightController != null)
+				Lights = new RoomLight(lightController);
 
 			Facility.RegisterDoors(this, room.gameObject.GetComponentsInChildren<DoorVariant>());
 		}

--- a/NwPluginAPI/Core/Zones/FacilityRoom.cs
+++ b/NwPluginAPI/Core/Zones/FacilityRoom.cs
@@ -148,9 +148,9 @@ namespace PluginAPI.Core.Zones
 		{
 			Zone = zone;
 			Identifier = room;
-
-			if (room.TryGetComponent(out FlickerableLightController lightController))
-				Lights = new RoomLight(lightController);
+			
+			if(room.GetComponentInChildren<FlickerableLightController>())
+				Lights = new RoomLight(room.GetComponentInChildren<FlickerableLightController>());
 
 			Facility.RegisterDoors(this, room.gameObject.GetComponentsInChildren<DoorVariant>());
 		}

--- a/NwPluginAPI/Core/Zones/FacilityRoom.cs
+++ b/NwPluginAPI/Core/Zones/FacilityRoom.cs
@@ -148,7 +148,7 @@ namespace PluginAPI.Core.Zones
 		{
 			Zone = zone;
 			Identifier = room;
-			
+
 			if(room.GetComponentInChildren<FlickerableLightController>())
 				Lights = new RoomLight(room.GetComponentInChildren<FlickerableLightController>());
 


### PR DESCRIPTION
# Server.cs
* Added ``int PlayerCount => Player.Count;``
* Added ``PermissionsHandler PermissionsHandler => ServerStatic.GetPermissionsHandler();``
* Added ``double TPS => Math.Round(1f / Time.smoothDeltaTime);``
* Added  get or set ``float SpawnProtectDuration``
* Added get or set ``bool IsHeavilyModded``
* Added ``Broadcast Broadcast => Broadcast.Singleton``

# Player.cs
* Added ``PlayerRoleBase RoleBase => ReferenceHub.roleManager.CurrentRole;``
* Added ``Dictionary<ItemType, ushort> AmmoBag => ReferenceHub.inventory.UserInventory.ReserveAmmo;``
* Added get or set ``string RoleColor`` (serverRoles)
* Added get or set ``string RoleName``
* Added ``string UnitName => ReferenceHub.roleManager.CurrentRole is HumanRole humanRole ? humanRole.UnitName : null;``
* Added ``bool HasReservedSlot => ReservedSlot.HasReservedSlot(UserId, out _);``
* Added ``Vector3 Velocity => ReferenceHub.GetVelocity();``
* Added ``VoiceModuleBase VoiceModule => ReferenceHub.roleManager.CurrentRole is IVoiceRole voiceRole ? voiceRole.VoiceModule : null;`` Can be null
* Added ``VoiceChatChannel VoiceChannel => VoiceModule?.CurrentChannel ?? VoiceChatChannel.None;``
* Change ``bool IsScp => Role.GetTeam() is Team.SCPs;``
* Added ``bool IsNTF => Role.GetTeam() is Team.FoundationForces;``
* Added ``bool IsCHI => Role.GetTeam() is Team.ChaosInsurgency;``
* Added ``bool IsTutorial => Role is RoleTypeId.Tutorial;``
* Added ``SetGroup(UserGroup group) ReferenceHub.serverRoles.SetGroup(group, false);``

# Fixes
* Fixed a bug where FacilityRooms.Light was always null  fix #152 
* Fixed a bug that caused SendBroadcast to occasionally throw NRE errors  fix #151 