### PR TITLE
New events

### DIFF
--- a/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
+++ b/Analyzers/NWPluginAPI.Analyzers/Generated/GeneratedEventManager.cs
@@ -423,5 +423,22 @@ public static class EventManager
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
 		{ 122, new Event(
 			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+		{ 123, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("InventorySystem.Items.Radio.RadioItem", false, "radio"),
+			new EventParameter("System.Single", false, "drain")) },
+		{ 124, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("PlayerStatsSystem.DamageHandlerBase", false, "damageHandler"),
+			new EventParameter("System.String", false, "announcement")) },
+		{ 125, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("UserGroup", false, "group")) },
+		{ 126, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player")) },
+		{ 127, new Event(
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "player"),
+			new EventParameter("PluginAPI.Core.Interfaces.IPlayer", false, "attacker"),
+			new EventParameter("PlayerStatsSystem.DamageHandlerBase", false, "damageHandler")) },
 	};
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -53,12 +53,12 @@ namespace PluginAPI.Enums
 		PlayerLeft = 1,
 
 		/// <summary>
-		/// Executed when player dies.
+		/// Executed before a player dies.
 		/// </summary>
 		/// <remarks>
 		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> attacker, <see cref="DamageHandlerBase"/> damageHandler.
 		/// </remarks>
-		PlayerDeath = 2,
+		PlayerDying  = 2,
 
 		/// <summary>
 		/// Executed when decontamination in LCZ starts.
@@ -1050,5 +1050,13 @@ namespace PluginAPI.Enums
 		/// </remarks>
 		/// </summary>
 		PlayerUsingIntercom = 126,
+
+		/// <summary>
+		/// Executed after a player dies.
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="IPlayer"/> attacker, <see cref="DamageHandlerBase"/> damageHandler.
+		/// </remarks>
+		/// </summary>
+		PlayerDeath,
 	}
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -1,4 +1,5 @@
 using Footprinting;
+using InventorySystem.Items.Radio;
 using PlayerRoles.PlayableScps.Scp079.Cameras;
 using PlayerRoles.PlayableScps.Scp096;
 using PluginAPI.Events;
@@ -1017,5 +1018,29 @@ namespace PluginAPI.Enums
 		/// Parameters: <see cref="IPlayer"/> player
 		/// </remarks>
 		Scp096StartCrying = 122,
+
+		/// <summary>
+		/// Executed when a player drain radio battery.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="RadioItem"/> radio, <see cref="float"/> drain.
+		/// </remarks>
+		PlayerUsingRadio = 123,
+
+		/// <summary>
+		/// Executed before CASSIE announces an SCP termination
+		/// </summary>
+		/// <remarks>
+		/// Params: <see cref="IPlayer"/> player, <see cref="DamageHandlerBase"/> damageHandler <see cref="string"/> announcement
+		/// </remarks>
+		CassieAnnouncesScpTermination = 124,
+
+		/// <summary>
+		/// Executed before a player changes is UserGroup.
+		/// </summary>
+		/// <remarks>
+		/// Params: <see cref="IPlayer"/> player, <see cref="UserGroup"/> group.
+ 		/// </remarks>
+		PlayerChangingGroup = 125,
 	}
 }

--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -1042,5 +1042,13 @@ namespace PluginAPI.Enums
 		/// Params: <see cref="IPlayer"/> player, <see cref="UserGroup"/> group.
  		/// </remarks>
 		PlayerChangingGroup = 125,
+
+		/// <summary>
+		/// Executed while a player is using intercom.
+		/// <remarks>
+		/// Params: <see cref="IPlayer"/> player
+		/// </remarks>
+		/// </summary>
+		PlayerUsingIntercom = 126,
 	}
 }

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -679,6 +679,26 @@ namespace PluginAPI.Events
 			{
 				ServerEventType.Scp096StartCrying, new Event(
 					new EventParameter(typeof(IPlayer), "player"))
+			},
+			{
+				ServerEventType.PlayerUsingRadio, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(RadioItem), "radio"),
+					new EventParameter(typeof(float), "drain")
+					)
+			},
+			{
+				ServerEventType.CassieAnnouncesScpTermination, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(DamageHandlerBase), "damageHandler"),
+					new EventParameter(typeof(String), "announcement")
+					)
+			},
+			{
+				ServerEventType.PlayerChangingGroup, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(UserGroup), "group")
+					)
 			}
 		};
 

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -699,7 +699,13 @@ namespace PluginAPI.Events
 					new EventParameter(typeof(IPlayer), "player"),
 					new EventParameter(typeof(UserGroup), "group")
 					)
+			},
+			{
+				ServerEventType.PlayerUsingIntercom, new Event(
+					new EventParameter(typeof(IPlayer), "player")
+					)
 			}
+
 		};
 
 		private static bool ValidateEvent(Type[] parameters, Type[] requiredParameters)

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -1,6 +1,7 @@
 using Footprinting;
 using PlayerRoles.PlayableScps.Scp079.Cameras;
 using PlayerRoles.PlayableScps.Scp096;
+using PlayerRoles.Voice;
 
 namespace PluginAPI.Events
 {
@@ -702,7 +703,8 @@ namespace PluginAPI.Events
 			},
 			{
 				ServerEventType.PlayerUsingIntercom, new Event(
-					new EventParameter(typeof(IPlayer), "player")
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(IntercomState), "intercomState")
 					)
 			},
 			{

--- a/NwPluginAPI/Events/EventManager.cs
+++ b/NwPluginAPI/Events/EventManager.cs
@@ -61,7 +61,7 @@ namespace PluginAPI.Events
 					new EventParameter(typeof(IPlayer), "player"))
 			},
 			{
-				ServerEventType.PlayerDeath, new Event(
+				ServerEventType.PlayerDying, new Event(
 					new EventParameter(typeof(IPlayer), "player"),
 					new EventParameter(typeof(IPlayer), "attacker"),
 					new EventParameter(typeof(DamageHandlerBase), "damageHandler"))
@@ -704,7 +704,13 @@ namespace PluginAPI.Events
 				ServerEventType.PlayerUsingIntercom, new Event(
 					new EventParameter(typeof(IPlayer), "player")
 					)
-			}
+			},
+			{
+				ServerEventType.PlayerDeath, new Event(
+					new EventParameter(typeof(IPlayer), "player"),
+					new EventParameter(typeof(IPlayer), "attacker"),
+					new EventParameter(typeof(DamageHandlerBase), "damageHandler"))
+			},
 
 		};
 

--- a/TemplatePlugin/MainClass.cs
+++ b/TemplatePlugin/MainClass.cs
@@ -2,6 +2,7 @@
 using Interactables.Interobjects;
 using InventorySystem.Items.ThrowableProjectiles;
 using MapGeneration;
+using PlayerRoles.Voice;
 using UnityEngine;
 
 namespace TemplatePlugin
@@ -100,7 +101,7 @@ namespace TemplatePlugin
 			{
 				Log.Info(attacker == null
 					? $"Player &6{player.Nickname}&r (&6{player.UserId}&r) is dying, cause {damageHandler}"
-					: $"Player &6{attacker.Nickname}&r (&6{attacker.UserId}&r) is dying by &6{player.Nickname}&r (&6{player.UserId}&r), cause {damageHandler}");
+					: $"Player &6{player.Nickname}&r (&6{player.UserId}&r) is dying by &6{attacker.Nickname}&r (&6{attacker.UserId}&r), cause {damageHandler}");
 				// The event runs normally
 				return true;
 			}
@@ -218,7 +219,7 @@ namespace TemplatePlugin
 		}
 
 		[PluginEvent(ServerEventType.PlayerUsingIntercom)]
-		void OnPlayerUsingIntercom(MyPlayer player)
+		void OnPlayerUsingIntercom(MyPlayer player, IntercomState state)
 		{
 			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is using Intercom");
 		}

--- a/TemplatePlugin/MainClass.cs
+++ b/TemplatePlugin/MainClass.cs
@@ -1,6 +1,7 @@
 ﻿using Footprinting;
 using Interactables.Interobjects;
 using InventorySystem.Items.ThrowableProjectiles;
+using MapGeneration;
 using UnityEngine;
 
 namespace TemplatePlugin
@@ -84,6 +85,25 @@ namespace TemplatePlugin
 		void OnPlayerLeave(MyPlayer player)
 		{
 			Log.Info($"Player &6{player.UserId}&r left this server with of &1{player.Test}&4");
+		}
+
+		[PluginEvent(ServerEventType.PlayerDying)]
+		bool OnPlayerDying(MyPlayer player, MyPlayer attacker, DamageHandlerBase damageHandler)
+		{
+			var condition = false;
+			if (condition is true)
+			{
+				// The event is canceled and the player does not die
+				return false;
+			}
+			else
+			{
+				Log.Info(attacker == null
+					? $"Player &6{player.Nickname}&r (&6{player.UserId}&r) is dying, cause {damageHandler}"
+					: $"Player &6{attacker.Nickname}&r (&6{attacker.UserId}&r) is dying by &6{player.Nickname}&r (&6{player.UserId}&r), cause {damageHandler}");
+				// The event runs normally
+				return true;
+			}
 		}
 
 		[PluginEvent(ServerEventType.PlayerDeath)]
@@ -177,6 +197,30 @@ namespace TemplatePlugin
 		void OnPlayerChangesRadioRange(MyPlayer plr, RadioItem item, byte range)
 		{
 			Log.Info($"Player &6{plr.Nickname}&r (&6{plr.UserId}&r) changed radio range to &6{range}&r");
+		}
+
+		[PluginEvent(ServerEventType.PlayerUsingRadio)]
+		void OnPlayerUsingRadio(MyPlayer player, RadioItem radio, float drain)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is using a radio and its draining &6{drain}&r of the battery");
+		}
+
+		[PluginEvent(ServerEventType.CassieAnnouncesScpTermination)]
+		void OnCassieAnnouncScpTermination(MyPlayer scp, DamageHandlerBase damage, string announcement)
+		{
+			Log.Info($"Cassie announce a SCP termination of player &6{scp.Nickname}&r (&6{scp.UserId}&r), CASSIE announcement is &6{announcement}&r");
+		}
+
+		[PluginEvent(ServerEventType.PlayerChangingGroup)]
+		void OnPlayerChangeGroup(MyPlayer player, UserGroup group)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is changing to group &6{group.BadgeText}&r");
+		}
+
+		[PluginEvent(ServerEventType.PlayerUsingIntercom)]
+		void OnPlayerUsingIntercom(MyPlayer player)
+		{
+			Log.Info($"Player &6{player.Nickname}&r (&6{player.UserId}&r) is using Intercom");
 		}
 
 		[PluginEvent(ServerEventType.PlayerChangeSpectator)]
@@ -451,12 +495,13 @@ namespace TemplatePlugin
 			Log.Info($"Round started");
 		}
 
-
 		[PluginEvent(ServerEventType.WaitingForPlayers)]
 		void WaitingForPlayers()
 		{
 			Log.Info($"Waiting for players...");
 		}
+
+
 
 		[PluginConfig] public MainConfig PluginConfig;
 


### PR DESCRIPTION
* New event ``PlayerUsingRadio`` Params: IPlayer, RadioItem, float drain

 Zabs this execute in RadioItem.Update() before applying this_battery = float, but after defining the float value, so players can set whether they want to spend battery power on the radio or change the usage.

* New event ``CassieAnnouncesScpTermination`` Params: IPlayer, DamageHandlerBase, string announcement

 This event executed in NineTailedFoxAnnouncer.AnnounceScpTermination after the string announcement is set, but before checking if it is empty or null.

Resolves #137

* New event ``PlayerChangingGroup`` Params: IPlayer, UserGroup

Executed in ServerRoles.SetGroup

* New event ``PlayerUsingIntercom`` Params: IPlayer, IntercomState

Executed in Intercom.Update()
Resolves #149 

* Rename event ``PlayerDeath`` => ``PlayerDying``

Executes before a player dies, this maybe Resolves #108

* "new" event ``PlayerDeath``

Executed after a player dies