### PR TITLE
Fix plugin loading

### DIFF
--- a/NwPluginAPI/Loader/AssemblyLoader.cs
+++ b/NwPluginAPI/Loader/AssemblyLoader.cs
@@ -117,6 +117,8 @@ namespace PluginAPI.Loader
 				.Select(x =>
 					$"{x.GetName().Name}&r v&6{x.GetName().Version.ToString(3)}");
 
+			var pluginInfoList = new List<PluginFileInformation>();
+
 			foreach (string pluginPath in files)
 			{
 				if (!TryGetAssembly(pluginPath, out Assembly assembly))
@@ -147,6 +149,17 @@ namespace PluginAPI.Loader
 					Log.Error($"Failed loading plugin &2{Path.GetFileNameWithoutExtension(pluginPath)}&r, {e.ToString()}");
 					continue;
 				}
+
+				pluginInfoList.Add(new PluginFileInformation(pluginPath, assembly, types));
+			}
+
+			Log.Info($"Initializing &2{pluginInfoList.Count}&r plugins...");
+
+			foreach (var info in pluginInfoList)
+			{
+				string pluginPath = info.Path;
+				var assembly = info.PluginAssembly;
+				Type[] types = info.Types;
 
 				foreach (var entryType in types)
 				{

--- a/NwPluginAPI/Loader/PluginFileInformation.cs
+++ b/NwPluginAPI/Loader/PluginFileInformation.cs
@@ -1,0 +1,22 @@
+namespace PluginAPI.Loader
+{
+	using System;
+	using System.Reflection;
+
+	public readonly struct PluginFileInformation
+	{
+		public readonly string Path;
+
+		public readonly Assembly PluginAssembly;
+
+		public readonly Type[] Types;
+
+		public PluginFileInformation(string path, Assembly pluginAssembly, Type[] types)
+		{
+			Path = path;
+			PluginAssembly = pluginAssembly;
+			Types = types;
+		}
+	}
+
+}


### PR DESCRIPTION
# Cross-plugin dependency fix

This PR fixes an issue where plugins would not load if they referenced another plugin that was not yet loaded.

## The problem:

**Assume the following scenario:**

The following plugins are to be loaded:

- PluginA
- PluginB
- PluginC

Both `PluginA` and `PluginC` depend on `PluginB`. `PluginB` has no dependencies.

1. `PluginA`'s assembly is loaded.
2. The loader attempts to initialize `PluginA`, but fails because the dependency `PluginB` is not yet found.
3. `PluginB`'s assembly is loaded and initialized.
4. `PluginC` is loaded and starts without any issues.

## Changes:

- Added the `PluginAPI.Loader.PluginFileInformation` struct
- Upon loading of a plugin assembly, it is not checked for entry points. If there are no missing references, the plugin information is added to a list.
- A message is printed to the console: `Initializing (count) plugins...`
- The list of plugins is iterated over and initialized.

This way, a plugin can reference another which comes after it alphabetically, and will still be initialized correctly.