### PR TITLE
New events for SCP-049, SCP-049-2 and Player

### DIFF
--- a/NwPluginAPI/Enums/ServerEventType.cs
+++ b/NwPluginAPI/Enums/ServerEventType.cs
@@ -29,6 +29,8 @@ namespace PluginAPI.Enums
 	using Interactables.Interobjects.DoorUtils;
 	using Interactables.Interobjects;
 	using Scp914;
+	using Hazards;
+	using PlayerRoles.PlayableScps.Scp049;
 
 	/// <summary>
 	/// Represents server event types.
@@ -1087,5 +1089,49 @@ namespace PluginAPI.Enums
 		/// Parameters: <see cref="IPlayer"/> player, <see cref="ItemType"/> type. <see cref="int"/> amount.
 		/// </remarks>
 		PlayerDroppedAmmo = 131,
+
+		/// <summary>
+		/// Executed when player enters a <see cref="EnvironmentalHazard"/>.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="EnvironmentalHazard"/> hazard.
+		/// </remarks>
+		PlayerEnterEnvironmentalHazard = 132,
+
+		/// <summary>
+		/// Executed when player stays in an <see cref="EnvironmentalHazard"/>.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="EnvironmentalHazard"/> hazard.
+		/// </remarks>
+		PlayerStayOnEnvironmentalHazard = 133,
+
+		/// <summary>
+		/// Executed when player exits a <see cref="EnvironmentalHazard"/>.
+		/// </summary>
+		/// <remarks>
+		/// Parameters: <see cref="IPlayer"/> player, <see cref="EnvironmentalHazard"/> hazard.
+		/// </remarks>
+		PlayerExitEnvironmentalHazard = 134,
+
+		/// <summary>
+		/// Executed when player consume a corpse as SCP-049-2
+		/// </summary>
+		Scp0492ConsumeCorpse = 135,
+
+		/// <summary>
+		/// Executed when a player as SCP-049 mark a player with SenseAbilty.
+		/// </summary>
+		Scp049MarkPlayer = 136,
+
+		/// <summary>
+		/// Executed when a player as SCP-049 lose a player with SenseAbility.
+		/// </summary>
+		Scp049LosingPlayer = 137,
+
+		/// <summary>
+		/// Executed when a player as SCP-049 use <see cref="Scp049CallAbility"/>
+		/// </summary>
+		Scp049CallProgeny = 138
 	}
 }

--- a/NwPluginAPI/Events/Args/Player/PlayerEnterEnvironmentalHazard.cs
+++ b/NwPluginAPI/Events/Args/Player/PlayerEnterEnvironmentalHazard.cs
@@ -1,0 +1,31 @@
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+using Hazards;
+
+namespace PluginAPI.Events.Args.Player
+{
+	public class PlayerEnterEnvironmentalHazard : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.PlayerEnterEnvironmentalHazard;
+
+		/// <summary>
+		/// Gets the player who is entering the enviromental hazard.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Player { get; }
+
+		/// <summary>
+		/// Gets the enviromental hazard which the player is entering.
+		/// </summary>
+		[EventArgument]
+		public EnvironmentalHazard EnvironmentalHazard { get; }
+
+		public PlayerEnterEnvironmentalHazard(ReferenceHub hub, EnvironmentalHazard hazard)
+		{
+			Player = Core.Player.Get(hub);
+			EnvironmentalHazard = hazard;
+		}
+
+		PlayerEnterEnvironmentalHazard() { }
+	}
+}

--- a/NwPluginAPI/Events/Args/Player/PlayerExitEnviromantalHazard.cs
+++ b/NwPluginAPI/Events/Args/Player/PlayerExitEnviromantalHazard.cs
@@ -1,0 +1,31 @@
+using Hazards;
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+
+namespace PluginAPI.Events.Args.Player
+{
+	public class PlayerExitEnviromantalHazard : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.PlayerExitEnvironmentalHazard;
+
+		/// <summary>
+		/// Gets the player who is exiting the enviromental hazard.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Player { get; }
+
+		/// <summary>
+		/// Gets the enviromental hazard which the player is exiting.
+		/// </summary>
+		[EventArgument]
+		public EnvironmentalHazard EnvironmentalHazard { get; }
+
+		public PlayerExitEnviromantalHazard(ReferenceHub hub, EnvironmentalHazard hazard)
+		{
+			Player = Core.Player.Get(hub);
+			EnvironmentalHazard = hazard;
+		}
+
+		public PlayerExitEnviromantalHazard() { }
+	}
+}

--- a/NwPluginAPI/Events/Args/Player/PlayerStayOnEnvironmentalHazard.cs
+++ b/NwPluginAPI/Events/Args/Player/PlayerStayOnEnvironmentalHazard.cs
@@ -1,0 +1,31 @@
+using Hazards;
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+
+namespace PluginAPI.Events.Args.Player
+{
+	public class PlayerStayOnEnvironmentalHazard : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.PlayerStayOnEnvironmentalHazard;
+
+		/// <summary>
+		/// Gets the player who is staying the enviromental hazard.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Player { get; }
+
+		/// <summary>
+		/// Gets the enviromental hazard which the player is staying.
+		/// </summary>
+		[EventArgument]
+		public EnvironmentalHazard EnvironmentalHazard { get; }
+
+		public PlayerStayOnEnvironmentalHazard(ReferenceHub hub, EnvironmentalHazard hazard)
+		{
+			Player = Core.Player.Get(hub);
+			EnvironmentalHazard = hazard;
+		}
+
+		public PlayerStayOnEnvironmentalHazard() { }
+	}
+}

--- a/NwPluginAPI/Events/Args/Scp049/Scp049CallProgeny.cs
+++ b/NwPluginAPI/Events/Args/Scp049/Scp049CallProgeny.cs
@@ -1,0 +1,35 @@
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PluginAPI.Events.Args.Scp049
+{
+	public class Scp049CallProgeny : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.Scp049CallProgeny;
+
+		/// <summary>
+		/// Gets the player who is playing as SCP-049.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Scp049 { get; }
+
+		/// <summary>
+		/// Gets or set the duration of the ability.
+		/// </summary>
+		[EventArgument]
+		public double Duration { get; set; }
+
+		public Scp049CallProgeny(ReferenceHub scp049, double duration)
+		{
+			Scp049 = Core.Player.Get(scp049);
+			Duration = duration;
+		}
+
+		Scp049CallProgeny() { }
+	}
+}

--- a/NwPluginAPI/Events/Args/Scp049/Scp049LoseMarkedPlayer.cs
+++ b/NwPluginAPI/Events/Args/Scp049/Scp049LoseMarkedPlayer.cs
@@ -1,0 +1,39 @@
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PluginAPI.Events.Args.Scp049
+{
+	public class Scp049LoseMarkedPlayer : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.Scp049LosingPlayer;
+
+		/// <summary>
+		/// Gets the player who is playing as SCP-049.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Scp049 { get; }
+
+		/// <summary>
+		/// Gets the player who escaped from SCP-049.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Target { get; }
+
+		/// <summary>
+		/// Get or set the cooldown for losing a target.
+		/// </summary>
+		[EventArgument]
+		public double Cooldown { get; set; } 
+
+		public Scp049LoseMarkedPlayer(ReferenceHub scp049, ReferenceHub target)
+		{
+			Scp049 = Core.Player.Get(scp049);
+			Target = Core.Player.Get(target);
+		}
+	}
+}

--- a/NwPluginAPI/Events/Args/Scp049/Scp049MarkPlayer.cs
+++ b/NwPluginAPI/Events/Args/Scp049/Scp049MarkPlayer.cs
@@ -1,0 +1,43 @@
+using Hazards;
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PluginAPI.Events.Args.Scp049
+{
+	public class Scp049MarkPlayer : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.Scp049MarkPlayer;
+
+		/// <summary>
+		/// Gets the player playing as SCP-049.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Scp049 { get; }
+
+		/// <summary>
+		/// Gets the player marked.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Target { get; }
+
+		/// <summary>
+		/// Get or set mark duration.
+		/// </summary>
+		[EventArgument]
+		public double Duration { get; set; }
+
+		public Scp049MarkPlayer(ReferenceHub scp049, ReferenceHub target, double duration)
+		{
+			Scp049 = Core.Player.Get(scp049);
+			Target = Core.Player.Get(target);
+			Duration = duration;
+		}
+
+		Scp049MarkPlayer() { }
+	}
+}

--- a/NwPluginAPI/Events/Args/Scp0492/Scp0492ConsumeCorpse.cs
+++ b/NwPluginAPI/Events/Args/Scp0492/Scp0492ConsumeCorpse.cs
@@ -1,0 +1,37 @@
+using PluginAPI.Core.Attributes;
+using PluginAPI.Enums;
+
+namespace PluginAPI.Events.Args.Scp0492
+{
+	public class Scp0492ConsumeCorpse : IEventArguments
+	{
+		public ServerEventType BaseType { get; } = ServerEventType.Scp0492ConsumeCorpse;
+
+		/// <summary>
+		/// Gets the player who is playing as SCP-049-2.
+		/// </summary>
+		[EventArgument]
+		public Core.Player Player { get; }
+
+		/// <summary>
+		/// Gets the corpse consumed.
+		/// </summary>
+		[EventArgument]
+		public BasicRagdoll CorpseConsumed { get; }
+
+		/// <summary>
+		/// Gets or sets the amount of healing for consuming a corpse.
+		/// </summary>
+		[EventArgument]
+		public float Heal { get; set; }
+
+		public Scp0492ConsumeCorpse(ReferenceHub zombie, BasicRagdoll corpseConsumed, float healAmount)
+		{
+			Player = Core.Player.Get(zombie);
+			CorpseConsumed = corpseConsumed;
+			Heal = healAmount;
+		}
+
+		Scp0492ConsumeCorpse() { }
+	}
+}


### PR DESCRIPTION
# SCP-049
* New event Scp049CallProgeny
   * Executed in Scp049CallAbility.ServerProcessCmd

* New event Scp049MarkPlayer and Scp049LoseMarkedPlayer
  * Executed in Scp049SenseAbility.ServerProcessCmd and Scp049SenseAbility.ServerLoseTarget

# SCP-049-2
* New event Scp0492ConsumeCorpse
   * Executed in ZombieConsumeAbility.ServerComplete

# Player
* New events **PlayerEnterEnvironmentalHazard**,  **PlayerStayOnEnvironmentalHazard**, **PlayerExitEnviromantalHazard**
   * Executed in EnvironmentalHazard