### PR TITLE
Fix typo in Player.cs

### DIFF
--- a/NwPluginAPI/Core/Player.cs
+++ b/NwPluginAPI/Core/Player.cs
@@ -630,10 +630,14 @@ namespace PluginAPI.Core
 			}
 		}
 
-		/// <summary>
+
+		[Obsolete("Use MaxArtificialHealth instead")]
+		public float MaxArtificalHealth => MaxArtificialHealth;
+
+        /// <summary>
 		/// Gets the player's current maximum artifical health.
 		/// </summary>
-		public float MaxArtificalHealth => IsSCP ? ((HumeShieldStat)ReferenceHub.playerStats.StatModules[4]).MaxValue : ((AhpStat)ReferenceHub.playerStats.StatModules[1]).MaxValue;
+		public float MaxArtificialHealth => IsSCP ? ((HumeShieldStat)ReferenceHub.playerStats.StatModules[4]).MaxValue : ((AhpStat)ReferenceHub.playerStats.StatModules[1]).MaxValue;
 
 		/// <summary>
 		/// Gets whether or not the player has remoteadmin access.


### PR DESCRIPTION
MaxArtificalHealth  => MaxArtificialHealth
Thanks to Steven4547466 for pointing out the typo error.
**I made this PR from Github so it's probably missing a using but you will notice it when you compile**